### PR TITLE
Fixed relative pathing to absolute pathing for MegaCli64

### DIFF
--- a/flash-it.sh
+++ b/flash-it.sh
@@ -102,9 +102,9 @@ if [ ! -f "${MEGACLI_FILE_NAME}" ]; then
 fi
 
 # Display SAS address and dump to file
-opt/MegaRAID/MegaCli/MegaCli64 -AdpAllInfo -a${ADAPTER_INDEX} | grep SAS\ Address
+/opt/MegaRAID/MegaCli/MegaCli64 -AdpAllInfo -a${ADAPTER_INDEX} | grep SAS\ Address
 BACKUP_SAS_ADDRESS_FILE="$(find ${BACKUP_ROOT_DIR} -name sas_address.txt)"
-SAS_ADDRESS="$(opt/MegaRAID/MegaCli/MegaCli64 -AdpAllInfo -a${ADAPTER_INDEX} | grep -E 'SAS Address[^:]*:\W*(\w+)' | cut -d':' -f2 | cut -d' ' -f2)"
+SAS_ADDRESS="$(/opt/MegaRAID/MegaCli/MegaCli64 -AdpAllInfo -a${ADAPTER_INDEX} | grep -E 'SAS Address[^:]*:\W*(\w+)' | cut -d':' -f2 | cut -d' ' -f2)"
 if [ ${#SAS_ADDRESS} -ne 16 ]; then
   echo "Could not retrieve SAS address from MegaCli, attempting to load from existing backup file."
   [ ! -f "${BACKUP_SAS_ADDRESS_FILE}" ] && echo "Error: unable to locate SAS address backup file. No changes have been made." && exit 1


### PR DESCRIPTION
MegaCli64 could not be found nor executed due to relative pathing. This commit changes the relative path of MegaCli64 to an absolute path.

This script made it very easy to flash my H310 mini. Thank you. I had to make this one slight change to get it to flash correctly.
Flashed successfully on H310 mini in a R720 server with a fresh Ubuntu Live 18.04.4 LTS.